### PR TITLE
Refactor CSS to use Tailwind utility classes and @apply

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -74,4 +74,18 @@ html.dark {
   color: var(--color-whitly);
 }
 
+/* Refactored component classes using @apply */
+.btn1 {
+    @apply flex justify-around items-center w-[90%] cursor-pointer rounded-[6px] min-w-[100px] m-[10px] p-[5px] border border-[--color-rangy] shadow-[0px_2px_5px_var(--color-rangy)] bg-[--color-whity] dark:bg-[--color-darky];
+}
+.btn1 svg {
+    @apply min-w-[20px] mx-[5px] text-[--color-darkly] dark:text-[--color-whitly];
+}
 
+.btn2 {
+    @apply flex justify-around items-center w-[90%] min-w-[100px] max-w-[400px] m-[10px] p-[5px] cursor-pointer bg-[--color-whity] rounded-[6px] border border-[--color-rangy] dark:bg-[--color-darky];
+}
+
+.btn3 {
+    @apply flex justify-around items-center m-[10px] w-[90%] min-w-[100px] max-w-[400px] p-[5px] cursor-pointer border border-[--color-rangy] bg-[--color-whity] rounded-[6px] shadow-[0px_2px_5px_var(--color-hoggari)] text-[--color-darkly] dark:bg-[--color-darky] dark:text-[--color-whitly];
+}

--- a/components/elements/bloc/gBtn.vue
+++ b/components/elements/bloc/gBtn.vue
@@ -1,15 +1,32 @@
 <template>
-  <button class="gBtn" :style="{ backgroundColor: color }" :id="value" type="button">
-    <div class="holder" v-if="text">{{ t(text) }}</div>
-    <div class="svg" :style="{color: color}" v-html="resizedImg" />
+  <button
+    class="m-[5px] flex h-8 cursor-pointer items-center justify-center overflow-visible rounded-full shadow-[0_2px_4px_rgba(0,0,0,0.3)]"
+    :style="{ backgroundColor: color }"
+    :id="value"
+    type="button"
+  >
+    <div
+      v-if="text"
+      class="mx-0.5 flex h-7 items-center rounded-full bg-[--color-whitly] p-2.5 text-sm dark:bg-[--color-darkly]"
+    >
+      {{ t(text) }}
+    </div>
+    <div
+      class="pointer-events-none flex h-[30px] w-[30px] items-center justify-center rounded-full text-[--color-whitly]"
+      v-html="resizedImg"
+    />
   </button>
 </template>
 
 <script setup>
-
 const { t } = useLang()
 
-const props = defineProps({ svg: String, text: String, value: Number, color: String })
+const props = defineProps({
+  svg: String,
+  text: String,
+  value: Number,
+  color: String,
+})
 
 const newWidth = 24
 const newHeight = 24
@@ -20,51 +37,4 @@ const resizedImg = computed(() => {
     .replace(/width="[^"]+"/, `width="${newWidth}"`)
     .replace(/height="[^"]+"/, `height="${newHeight}"`)
 })
-
-
 </script>
-
-<style>
-
-.gBtn {
-  height: 32px;
-  border-radius: 20px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  overflow: visible;
-  margin: 5px;
-  cursor: pointer;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-}
-
-.holder {
-  height: 28px;
-  padding: 10px;
-  margin-inline: 2px;
-  background-color: var(--color-whitly);
-  border-radius: 14px;
-  display: flex;
-  align-items: center;
-  font-size: 14px;
-}
-
-.dark .holder {
-  background-color: var(--color-darkly);
-}
-
-.gBtn .svg {
-  height: 30px;
-  width: 30px;
-  border-radius: 14px;
-  pointer-events: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.gBtn .svg svg {
-  color: var(--color-whitly);
-}
-
-
-</style>

--- a/components/elements/nav1.vue
+++ b/components/elements/nav1.vue
@@ -1,22 +1,25 @@
 <template>
-  <nav class="navMob" v-if="isMounted">
-    <NuxtLink class="webName" to="/">
+  <nav
+    v-if="isMounted"
+    class="sticky top-0 z-[5000] flex h-[50px] w-full items-center justify-center bg-[--color-whitly] backdrop-blur-[10px] shadow-[0_4px_8px_var(--color-tioly)] dark:bg-[--color-darkly] dark:shadow-[0_0px_8px_var(--color-darky)]"
+  >
+    <NuxtLink to="/" class="m-[5px] flex w-2/5 min-w-[120px] justify-start">
       <img v-if="!isDark" :src="logoDark" alt="Logo du site" class="h-10" />
       <img v-else :src="logoWhite" alt="Logo du site" class="h-10" />
     </NuxtLink>
 
-    <div class="whiteSpace"></div>
+    <div class="w-full"></div>
 
-    <NuxtLink v-if="isAuthenticated && isDeasy" class="dini" to="/diniChat">
-      <img v-if="!isDark" :style="{ height: '24px' }" :src="varqWhite" alt="Dini icon" />
-      <img v-else :style="{ height: '24px' }" :src="varqDark" alt="Dini white icon" />
+    <NuxtLink v-if="isAuthenticated && isDeasy" to="/diniChat" class="mx-[5px] flex min-w-[24px] max-w-[24px] cursor-pointer justify-center">
+      <img v-if="!isDark" :src="varqWhite" alt="Dini icon" class="h-6" />
+      <img v-else :src="varqDark" alt="Dini white icon" class="h-6" />
     </NuxtLink>
 
-    <button class="menu" @click="toggleDarkMode">
+    <button @click="toggleDarkMode" class="m-[5px] flex w-10 min-w-10 max-w-10 cursor-pointer justify-center transition-all duration-500 ease-in-out">
       <svg
         v-if="isDark"
         key="dark"
-        class="text-whity"
+        class="text-[--color-whity]"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
         width="24"
@@ -25,48 +28,33 @@
       >
         <path d="M17 12C17 14.7614 14.7614 17 12 17C9.23858 17 7 14.7614 7 12C7 9.23858 9.23858 7 12 7C14.7614 7 17 9.23858 17 12Z" stroke="currentColor" stroke-width="1.5" />
         <path d="M12 2V3.5M12 20.5V22M19.0708 19.0713L18.0101 18.0106M5.98926 5.98926L4.9286 4.9286M22 12H20.5M3.5 12H2M19.0713 4.92871L18.0106 5.98937M5.98975 18.0107L4.92909 19.0714" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+      </svg>
 
-          <!-- Icône mode sombre -->
-        </svg>
-
-        <svg v-else
-        key="light"
-        class="text-darkly"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        width="24"
-        height="24"
-        fill="none"
-        >
-          <path d="M18.6911 3.07767L19.395 4.49715C19.491 4.69475 19.7469 4.88428 19.9629 4.92057L21.2388 5.1343C22.0547 5.27141 22.2467 5.86824 21.6587 6.457L20.6668 7.45709C20.4989 7.62646 20.4069 7.9531 20.4589 8.18699L20.7428 9.425C20.9668 10.4049 20.4509 10.784 19.591 10.2718L18.3951 9.55808C18.1791 9.42903 17.8232 9.42903 17.6032 9.55808L16.4073 10.2718C15.5514 10.784 15.0315 10.4009 15.2554 9.425L15.5394 8.18699C15.5914 7.9531 15.4994 7.62646 15.3314 7.45709L14.3395 6.457C13.7556 5.86824 13.9436 5.27141 14.7595 5.1343L16.0353 4.92057C16.2473 4.88428 16.5033 4.69475 16.5993 4.49715L17.3032 3.07767C17.6872 2.30744 18.3111 2.30744 18.6911 3.07767Z" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-          <path d="M3 11.8049C3 17.1594 7.34065 21.5 12.6951 21.5C17.101 21.5 20.8204 18.5611 22 14.5367C20.5791 15.5691 18.8306 16.1779 16.94 16.1779C12.1804 16.1779 8.32208 12.3196 8.32208 7.56005C8.32208 5.66937 8.93094 3.9209 9.96326 2.5C5.9389 3.67959 3 7.39904 3 11.8049Z" stroke="#000000" stroke-width="1.5" stroke-linejoin="round"></path>
-        </svg>
+      <svg v-else key="light" class="text-[--color-darkly]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
+        <path d="M18.6911 3.07767L19.395 4.49715C19.491 4.69475 19.7469 4.88428 19.9629 4.92057L21.2388 5.1343C22.0547 5.27141 22.2467 5.86824 21.6587 6.457L20.6668 7.45709C20.4989 7.62646 20.4069 7.9531 20.4589 8.18699L20.7428 9.425C20.9668 10.4049 20.4509 10.784 19.591 10.2718L18.3951 9.55808C18.1791 9.42903 17.8232 9.42903 17.6032 9.55808L16.4073 10.2718C15.5514 10.784 15.0315 10.4009 15.2554 9.425L15.5394 8.18699C15.5914 7.9531 15.4994 7.62646 15.3314 7.45709L14.3395 6.457C13.7556 5.86824 13.9436 5.27141 14.7595 5.1343L16.0353 4.92057C16.2473 4.88428 16.5033 4.69475 16.5993 4.49715L17.3032 3.07767C17.6872 2.30744 18.3111 2.30744 18.6911 3.07767Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+        <path d="M3 11.8049C3 17.1594 7.34065 21.5 12.6951 21.5C17.101 21.5 20.8204 18.5611 22 14.5367C20.5791 15.5691 18.8306 16.1779 16.94 16.1779C12.1804 16.1779 8.32208 12.3196 8.32208 7.56005C8.32208 5.66937 8.93094 3.9209 9.96326 2.5C5.9389 3.67959 3 7.39904 3 11.8049Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"></path>
+      </svg>
     </button>
 
     <ProfileBtn :user="user" />
 
-    <button v-if="isAuthenticated" class="menu" @click="sideBar">
-      <svg v-if="isVisible" :class="isDark ? 'text-whitly' : 'text-darkly'" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
-            <path d="M2 12C2 8.3109 2 6.46633 2.81382 5.1588C3.1149 4.67505 3.48891 4.2543 3.91891 3.91557C5.08116 3.00003 6.72077 3.00003 10 3.00003H14C17.2792 3.00003 18.9188 3.00003 20.0811 3.91557C20.5111 4.2543 20.8851 4.67505 21.1862 5.1588C22 6.46633 22 8.3109 22 12C22 15.6892 22 17.5337 21.1862 18.8413C20.8851 19.325 20.5111 19.7458 20.0811 20.0845C18.9188 21 17.2792 21 14 21H10C6.72077 21 5.08116 21 3.91891 20.0845C3.48891 19.7458 3.1149 19.325 2.81382 18.8413C2 17.5337 2 15.6892 2 12Z" stroke="currentColor" stroke-width="1.5"></path>
-            <path d="M14.5 3.00003L14.5 21" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"></path>
-            <path d="M18 7.00006H19M18 10.0001H19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-        </svg>
-        <svg v-else :class="isDark ? 'text-whitly' : 'text-darkly'" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
-            <path d="M4 5L20 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-            <path d="M4 12L20 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-            <path d="M4 19L20 19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-        </svg>
+    <button v-if="isAuthenticated" @click="sideBar" class="m-[5px] flex w-10 min-w-10 max-w-10 cursor-pointer justify-center transition-all duration-500 ease-in-out">
+      <svg v-if="isVisible" :class="isDark ? 'text-[--color-whitly]' : 'text-[--color-darkly]'" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
+        <path d="M2 12C2 8.3109 2 6.46633 2.81382 5.1588C3.1149 4.67505 3.48891 4.2543 3.91891 3.91557C5.08116 3.00003 6.72077 3.00003 10 3.00003H14C17.2792 3.00003 18.9188 3.00003 20.0811 3.91557C20.5111 4.2543 20.8851 4.67505 21.1862 5.1588C22 6.46633 22 8.3109 22 12C22 15.6892 22 17.5337 21.1862 18.8413C20.8851 19.325 20.5111 19.7458 20.0811 20.0845C18.9188 21 17.2792 21 14 21H10C6.72077 21 5.08116 21 3.91891 20.0845C3.48891 19.7458 3.1149 19.325 2.81382 18.8413C2 17.5337 2 15.6892 2 12Z" stroke="currentColor" stroke-width="1.5"></path>
+        <path d="M14.5 3.00003L14.5 21" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"></path>
+        <path d="M18 7.00006H19M18 10.0001H19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+      </svg>
+      <svg v-else :class="isDark ? 'text-[--color-whitly]' : 'text-[--color-darkly]'" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
+        <path d="M4 5L20 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+        <path d="M4 12L20 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+        <path d="M4 19L20 19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+      </svg>
     </button>
   </nav>
-
-  
 </template>
 
 <script setup>
 import ProfileBtn from './bloc/profileBtn.vue'
-
-//const { t, setLocale, locale } = useLang()
-
 
 defineProps({
   user: String,
@@ -79,69 +67,15 @@ defineProps({
   varqWhite: String,
   varqDark: String,
   isVisible: Boolean,
-
 })
 
-
-
-// Déclaration des emits
 const emit = defineEmits(['darkMode', 'sideBar', 'viewMenu', 'handleLogout'])
 
-// Méthode qui émet l'événement
 const toggleDarkMode = () => {
-
-    emit('darkMode')
+  emit('darkMode')
 }
 
 const sideBar = () => {
-    emit('sideBar')
-};
-
-
-
+  emit('sideBar')
+}
 </script>
-
-
-
-<style>
-.webName{
-display: flex;
-justify-content: left;
-width: 40%;
-min-width: 120px;
-margin: 5px;
-}
-
-.whiteSpace{
-width: 100%;
-}
-
-
-.menu{
-width: 40px;
-min-width: 40px;
-max-width: 40px;
-display: flex;
-justify-content: center;
-margin: 5px;
-cursor: pointer;
-transition: all 0.5s ease;
-}
-
-.menu svg {
-transition: all 0.5s ease;
-}
-
-
-.dini{
-min-width: 24px;
-max-width: 24px;
-display: flex;
-justify-content: center;
-margin-inline: 5px;
-cursor: pointer;
-
-}
-
-
-</style>

--- a/plugin/webNavBar.vue
+++ b/plugin/webNavBar.vue
@@ -111,71 +111,7 @@ line-height: 1.2em; /* Ajuste l'espacement des lignes */
 }
 
 
-.btn2{
-display: flex;
-justify-content: space-around;
-align-items: center;
-width: 90%;
-min-width: 100px;
-max-width: 400px;
-margin: 10px;
-padding: 5px;
-cursor: pointer;
-background-color: var(--color-whity);
-border-radius: 6px;
-border: 1px solid var(--color-rangy);
-}
-.dark .btn2{
-background-color: var(--color-darky);
-}
-
-.btn3{
-display: flex;
-justify-content: space-around;
-align-items: center;
-margin: 10px;
-width: 90%;
-min-width: 100px;
-max-width: 400px;
-padding: 5px;
-cursor: pointer;
-border: 1px solid var(--color-rangy);
-background-color: var(--color-whity);
-border-radius: 6px;
-box-shadow: 0px 2px 5px var(--color-hoggari);
-color: var(--color-darkly);
-}
-.dark .btn3{
-background-color: var(--color-darky);
-color: var(--color-whitly);
-}
-
-.btn1{
-display: flex;
-justify-content: space-around;
-align-items: center;
-width: 90%;
-cursor: pointer;
-border-radius: 6px;
-min-width: 100px;
-margin: 10px;
-padding: 5px;
-border: 1px solid var(--color-rangy);
-box-shadow: 0px 2px 5px var(--color-rangy);
-background-color: var(--color-whity);
-}
-.dark .btn1{
-background-color: var(--color-darky);
-}
-
-.btn1 svg{
-min-width: 20px;
-margin-inline: 5px;
-color: var(--color-darkly);
-}
-.dark .btn1 svg{
-color: var(--color-whitly);
-}
+/* .btn1, .btn2, .btn3 have been moved to assets/css/main.css and refactored with @apply */
 
 .input{
 display: flex;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1247,6 +1247,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
@@ -4868,8 +4873,8 @@ snapshots:
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.0
       '@rollup/pluginutils': 5.1.4(rollup@4.34.6)
-      acorn: 8.14.0
-      acorn-import-attributes: 1.9.5(acorn@8.14.0)
+      acorn: 8.14.1
+      acorn-import-attributes: 1.9.5(acorn@8.14.1)
       async-sema: 3.1.1
       bindings: 1.5.0
       estree-walker: 2.0.2
@@ -5032,18 +5037,20 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
-  acorn-import-attributes@1.9.5(acorn@8.14.0):
-    dependencies:
-      acorn: 8.14.0
-
-  acorn-jsx@5.3.2(acorn@8.14.1):
+  acorn-import-attributes@1.9.5(acorn@8.14.1):
     dependencies:
       acorn: 8.14.1
+
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
     optional: true
 
   acorn@8.14.0: {}
 
-  acorn@8.14.1:
+  acorn@8.14.1: {}
+
+  acorn@8.15.0:
     optional: true
 
   agent-base@7.1.3: {}
@@ -5592,8 +5599,8 @@ snapshots:
 
   espree@10.3.0:
     dependencies:
-      acorn: 8.14.1
-      acorn-jsx: 5.3.2(acorn@8.14.1)
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.0
     optional: true
 
@@ -6247,7 +6254,7 @@ snapshots:
 
   mlly@1.7.4:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
       pathe: 2.0.2
       pkg-types: 1.3.1
       ufo: 1.5.4
@@ -7291,7 +7298,7 @@ snapshots:
   terser@5.38.1:
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.14.0
+      acorn: 8.14.1
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -7349,7 +7356,7 @@ snapshots:
 
   unctx@2.4.1:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
       unplugin: 2.1.2
@@ -7376,7 +7383,7 @@ snapshots:
   unimport@3.14.6(rollup@4.34.6):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.34.6)
-      acorn: 8.14.0
+      acorn: 8.14.1
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       fast-glob: 3.3.3
@@ -7394,7 +7401,7 @@ snapshots:
 
   unimport@4.1.0:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       fast-glob: 3.3.3
@@ -7440,12 +7447,12 @@ snapshots:
 
   unplugin@1.16.1:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
       webpack-virtual-modules: 0.6.2
 
   unplugin@2.1.2:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
       webpack-virtual-modules: 0.6.2
 
   unstorage@1.14.4(db0@0.2.3)(ioredis@5.5.0):


### PR DESCRIPTION
This commit harmonizes the project's CSS by refactoring several key components and establishing a maintainable, utility-first approach with Tailwind CSS v4.

- Replaced custom classes in `nav1.vue` and `gBtn.vue` with Tailwind utility classes, removing their local `<style>` blocks.
- Identified common button styles (`.btn1`, `.btn2`, `.btn3`) and centralized them in `assets/css/main.css` using the `@apply` directive for reusability.
- Removed the original definitions of the button classes from `plugin/webNavBar.vue`.
- The changes were visually verified with Playwright to ensure no regressions were introduced.

This work addresses the fragmented and inconsistent styling, improving the overall harmony and maintainability of the CSS codebase.